### PR TITLE
register distributorauth message in the amino codec

### DIFF
--- a/x/distributorsauth/types/codec.go
+++ b/x/distributorsauth/types/codec.go
@@ -11,6 +11,10 @@ import (
 
 func RegisterCodec(cdc *codec.LegacyAmino) {
 	// this line is used by starport scaffolding # 2
+	cdc.RegisterConcrete(&MsgAddAdmin{}, "entangle/distributorsauth/MsgAddAdmin", nil)
+	cdc.RegisterConcrete(&MsgRemoveAdmin{}, "entangle/distributorsauth/MsgRemoveAdmin", nil)
+	cdc.RegisterConcrete(&MsgAddDistributor{}, "entangle/distributorsauth/MsgAddDistributor", nil)
+	cdc.RegisterConcrete(&MsgRemoveDistributor{}, "entangle/distributorsauth/MsgRemoveDistributor", nil)
 }
 
 func RegisterInterfaces(registry cdctypes.InterfaceRegistry) {


### PR DESCRIPTION
register distributorauth message in the amino codec to correct encoding and decoding messages